### PR TITLE
fix: issues #1, #2

### DIFF
--- a/src/__test__/core/options.test.ts
+++ b/src/__test__/core/options.test.ts
@@ -62,6 +62,7 @@ describe('core -> options.ts', () => {
       fetch: false,
       hashchange: false,
       history: false,
+      beforeunload: true,
       performance: false,
       recordScreen: false,
       whitescreen: false,
@@ -78,6 +79,7 @@ describe('core -> options.ts', () => {
       fetch: false,
       hashchange: false,
       history: true,
+      beforeunload: true,
       performance: false,
       recordScreen: false,
       whitescreen: false,
@@ -139,6 +141,19 @@ describe('core -> options.ts', () => {
         data: 'SUNSHINE',
       },
     ]);
+
+    const globalWithHandlerListener = {
+      selector: '.sunshine-test-class',
+      elementText: 'SUNSHINE_TEST_TEXT',
+      data: 'SUNSHINE',
+      handler: (ele: Node) => {
+        return ele.nodeName;
+      }
+    };
+    options.set({
+      globalClickListeners: [globalWithHandlerListener]
+    });
+    expect(options.getGlobalClickListeners()).toEqual([globalWithHandlerListener]);
   });
 
   it('Options report', () => {

--- a/src/core/event/event.ts
+++ b/src/core/event/event.ts
@@ -76,6 +76,16 @@ export class EventTrack {
     await this.clearReportData();
     report.send(data, () => this.clearReportData());
   }
+
+  async reportAll(data: IEventParams[]) {
+    const list = this.data;
+    if (!data.length && !list.length) {
+      return;
+    }
+    const finalList = [...list, ...data];
+    await this.clearReportData();
+    report.send(finalList, () => this.clearReportData());
+  }
 }
 
 const eventTrack = new EventTrack();

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -80,6 +80,7 @@ export class Options {
       whitescreen,
       hashchange,
       history,
+      beforeunload,
       performance,
       // recordScreen,
     } = this.getSwitchs();
@@ -89,6 +90,7 @@ export class Options {
     this.switchMap[EventType.WhiteScreen] = whitescreen;
     this.switchMap[EventType.HashChange] = hashchange;
     this.switchMap[EventType.History] = history;
+    this.switchMap[EventType.BeforeUnload] = beforeunload;
     this.switchMap[EventType.Performance] = performance;
   }
 
@@ -116,6 +118,7 @@ export class Options {
       whitescreen = false,
       hashchange = false,
       history = false,
+      beforeunload = true,
       recordScreen = false,
       performance = false,
     } = switchs;
@@ -127,6 +130,7 @@ export class Options {
       whitescreen,
       hashchange,
       history,
+      beforeunload,
       recordScreen,
       performance,
     };

--- a/src/core/setup/replace/index.ts
+++ b/src/core/setup/replace/index.ts
@@ -52,6 +52,11 @@ export const setupReplace = () => {
       type: EventType.WhiteScreen,
       callback: EventCollection[EventType.WhiteScreen],
     });
+  siwtchMap[EventType.BeforeUnload] &&
+    addListenOrReplace({
+      type: EventType.BeforeUnload,
+      callback: EventCollection[EventType.BeforeUnload],
+    });
   if (siwtchMap[EventType.Performance]) {
     new WebPerformance({ report })
   }

--- a/src/core/setup/replace/replace.ts
+++ b/src/core/setup/replace/replace.ts
@@ -33,6 +33,17 @@ const listenWindowClick = () => {
   });
 };
 
+const listenPageBeforeUnload = () => {
+  on({
+    el: _global,
+    eventName: 'beforeunload',
+    event: throttle(function (e: PointerEvent) {
+      emit(EventType.BeforeUnload, e);
+    }, 300),
+    capture: true,
+  });
+};
+
 const listenHashChange = () => {
   on({
     el: _global,
@@ -224,6 +235,9 @@ const listenOrReplace = (type: EventType) => {
       break;
     case EventType.WhiteScreen:
       whiteScreen();
+      break;
+    case EventType.BeforeUnload:
+      listenPageBeforeUnload();
       break;
   }
 };

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -52,7 +52,8 @@ export const enum EventType {
   Click = 'click',
   HashChange = 'hash_change',
   Http = 'http',
-  Resource = 'resource'
+  Resource = 'resource',
+  BeforeUnload = 'before_unload',
 }
 
 export interface IEventParams {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -19,6 +19,7 @@ export interface IGlobalClickListenerItem {
   selector?: string;
   elementText?: string;
   data?: string;
+  handler?: (el: Element | Node) => any;
 }
 
 export type UserIdType = string | (() => string);
@@ -30,6 +31,7 @@ export interface ISwitch {
   whitescreen: boolean;
   hashchange: boolean;
   history: boolean;
+  beforeunload: boolean;
   recordScreen: boolean;
   performance: boolean;
 }

--- a/src/utils/event-listener.ts
+++ b/src/utils/event-listener.ts
@@ -1,6 +1,7 @@
 import { isElement, isFunction, isNil } from 'lodash-es';
 
 export const NATIVE_EVENTS = [
+  'beforeunload',
   'click',
   'dblclick',
   'keydown',


### PR DESCRIPTION
优化issue#1（未达到阈值时，缓存的日志数据何时上报）
> 未达到阈值，当页面销毁前（beforeunload）将剩余数据上报，防止数据丢失。并增加beforeunload事件上报。

解决issue#2（建议:全局点击监听，能够将点击元素的dom节点传递过来，便于用户处理 ）
> 已增加支持自定义处理函数配置（handler: Function）